### PR TITLE
Arch image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,11 @@ on:
       - "*"
       paths-ignore:
       - README.md
+  pull_request:
+    branches:
+      - "*"
+    paths-ignore:
+    - README.md
 defaults:
     run:
         working-directory: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM debian:latest
+FROM archlinux:latest
 
-RUN apt update && apt install -y apt-transport-https ca-certificates wget gnupg
+#RUN pacman -Syu --noconfirm
+RUN pacman -Sy tor sudo --noconfirm
 
-RUN echo "deb [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org stable main" >> /etc/apt/sources.list.d/tor.list
-RUN echo "deb-src [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org stable main" >> /etc/apt/sources.list.d/tor.list
+RUN chown -R tor:tor /var/lib/tor/
 
-RUN wget -qO- https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor | tee /usr/share/keyrings/tor-archive-keyring.gpg >/dev/null
-
-RUN apt update && apt install -y tor deb.torproject.org-keyring
+#RUN chmod 700 -R /var/lib/tor/
 
 COPY config/torrc.exit.conf /etc/tor/torrc
 
 EXPOSE 9001 9030
 
-ENTRYPOINT ["/usr/bin/tor"]
+ENTRYPOINT ["/usr/bin/sudo", "-u", "tor", "/usr/bin/tor"]
+#ENTRYPOINT [ "/usr/bin/tor" ]
+#CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-all:
+all: dir
 	docker compose -f docker-compose.yml up --build
 build:
 	docker compose -f docker-compose.yml build
 clean:
 	docker rm tor-tor-1
 	docker image rm $$(docker images | grep 'tor-tor' | awk '{print $$3}')
+dir:
+	mkdir ../tor-data ../tor-log
+	chown tor:tor ../tor-data
+	chown tor:tor ../tor-log
 
 # For usage on CI
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ all:
 	docker compose -f docker-compose.yml up --build
 build:
 	docker compose -f docker-compose.yml build
-
+clean:
+	docker rm tor-tor-1
+	docker image rm $$(docker images | grep 'tor-tor' | awk '{print $$3}')
 
 # For usage on CI
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
       - "9001:9001" # relay
       - "9030:9030" # directory
     volumes:
-      - ../tor-data:/var/lib/tor
-      - ../tor-log:/var/log/tor
+      - ./tor-data:/var/lib/tor:rw
+      - ./tor-log:/var/log/tor:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,6 @@ services:
       - "9001:9001" # relay
       - "9030:9030" # directory
     volumes:
-      - ./tor-data:/var/lib/tor:rw
-      - ./tor-log:/var/log/tor:rw
+      # make sure the host directories are owned by user tor
+      - ../tor-data:/var/lib/tor:rw
+      - ../tor-log:/var/log/tor:rw


### PR DESCRIPTION
This PR uses Arch Linux docker image as the base image. Advantages are listed below:
1. tor is already inside Arch repo, no need to add additional repos, makes installation easier
2. Arch Linux packages are newer, which means vulnerabilities gets patched quicker. Plus Arch is on rolling release, so no need to worry about upgrading to a new release. 
3. ~~We use arch btw~~
Beside that, this version is configured to have TOR ran as user `tor` by default, where the default branch uses root, which is giving the application way more privileges than it needs . However, we must create the user `tor` on the server before using it.